### PR TITLE
vk: autogrow descriptor pools on demand — fixes GT5 high-memory crash (backport RPCS3 #18844)

### DIFF
--- a/app/src/main/cpp/rpcs3/rpcs3/Emu/RSX/VK/VKProgramPipeline.cpp
+++ b/app/src/main/cpp/rpcs3/rpcs3/Emu/RSX/VK/VKProgramPipeline.cpp
@@ -725,7 +725,7 @@ namespace vk
 		void descriptor_table_t::create_descriptor_pool()
 		{
 			m_descriptor_pool = std::make_unique<descriptor_pool>();
-			m_descriptor_pool->create(*vk::g_render_device, m_descriptor_pool_sizes);
+			m_descriptor_pool->create(*vk::g_render_device, m_descriptor_pool_sizes, 16u, 4096u);
 		}
 
 		void descriptor_table_t::validate() const

--- a/app/src/main/cpp/rpcs3/rpcs3/Emu/RSX/VK/vkutils/descriptors.cpp
+++ b/app/src/main/cpp/rpcs3/rpcs3/Emu/RSX/VK/vkutils/descriptors.cpp
@@ -110,17 +110,39 @@ namespace vk
 		}
 	}
 
-	void descriptor_pool::create(const vk::render_device& dev, const rsx::simple_array<VkDescriptorPoolSize>& pool_sizes, u32 max_sets)
+	u32 descriptor_pool::autoscaling_config_t::get_pool_size()
 	{
-		ensure(max_sets > 16);
+		if (current_size < min_pool_size)
+		{
+			current_size = min_pool_size;
+			return min_pool_size;
+		}
+
+		if (current_size >= max_pool_size)
+		{
+			current_size = max_pool_size;
+			return max_pool_size;
+		}
+
+		// Try grow
+		if ((increment_steps++) < (increment_min_steps - 1u))
+		{
+			return current_size;
+		}
+
+		increment_steps = 0u;
+		current_size = std::min(current_size * 2u, max_pool_size);
+		return current_size;
+	}
+
+	void descriptor_pool::create(const vk::render_device& dev, const rsx::simple_array<VkDescriptorPoolSize>& pool_sizes, u32 min_sets, u32 max_sets)
+	{
+		m_autoscaling_config.min_pool_size = std::max(min_sets, 16u);
+		m_autoscaling_config.max_pool_size = std::max(min_sets, max_sets);
+
+		ensure(m_autoscaling_config.max_pool_size >= 16u);
 
 		m_create_info_pool_sizes = pool_sizes;
-
-		for (auto& size : m_create_info_pool_sizes)
-		{
-			ensure(size.descriptorCount < 128); // Sanity check. Remove before commit.
-			size.descriptorCount *= max_sets;
-		}
 
 		m_create_info.flags = dev.get_descriptor_update_after_bind_support() ? VK_DESCRIPTOR_POOL_CREATE_UPDATE_AFTER_BIND_BIT : 0;
 		m_create_info.maxSets = max_sets;
@@ -186,7 +208,7 @@ namespace vk
 
 		if (use_cache)
 		{
-			const auto alloc_size = std::min<u32>(m_create_info.maxSets - m_current_subpool_offset, max_cache_size);
+			const auto alloc_size = std::min<u32>(max_sets() - m_current_subpool_offset, max_cache_size);
 			m_allocation_request_cache.resize(alloc_size);
 			for (auto& layout_ : m_allocation_request_cache)
 			{
@@ -243,8 +265,8 @@ namespace vk
 				}
 			}
 
-			VkDescriptorPool subpool = VK_NULL_HANDLE;
-			if (VkResult result = _vkCreateDescriptorPool(*m_owner, &m_create_info, nullptr, &subpool))
+			const auto [result, subpool] = new_subpool();
+			if (result != VK_SUCCESS)
 			{
 				if (retries-- && (result == VK_ERROR_FRAGMENTATION_EXT))
 				{
@@ -263,6 +285,7 @@ namespace vk
 			m_device_subpools.push_back(
 			{
 				.handle = subpool,
+				.size = m_autoscaling_config.current_size,
 				.busy = VK_FALSE
 			});
 
@@ -273,6 +296,40 @@ namespace vk
 	done:
 		m_device_subpools[m_current_subpool_index].busy = VK_TRUE;
 		m_current_pool_handle = m_device_subpools[m_current_subpool_index].handle;
+	}
+
+	std::pair<VkResult, VkDescriptorPool> descriptor_pool::new_subpool()
+	{
+		// Try autoscaling
+		const auto prev_scaling_config = m_autoscaling_config;
+		const u32 set_count = m_autoscaling_config.get_pool_size();
+
+		// Configure request using current pool size
+		auto descriptor_pool_sizes = m_create_info_pool_sizes.map([set_count](const VkDescriptorPoolSize& pool_size_info)
+		{
+			auto ret = pool_size_info;
+			ret.descriptorCount *= set_count;
+			return ret;
+		});
+
+		m_create_info.maxSets = set_count;
+		m_create_info.poolSizeCount = descriptor_pool_sizes.size();
+		m_create_info.pPoolSizes = descriptor_pool_sizes.data();
+
+		VkDescriptorPool subpool = VK_NULL_HANDLE;
+		VkResult result = _vkCreateDescriptorPool(*m_owner, &m_create_info, nullptr, &subpool);
+
+		if (result != VK_SUCCESS)
+		{
+			// Roll back autoscaling
+			m_autoscaling_config = prev_scaling_config;
+		}
+
+		// Cleanup
+		m_create_info.pPoolSizes = nullptr;
+		m_create_info.poolSizeCount = 0;
+
+		return { result, subpool };
 	}
 
 	descriptor_set::descriptor_set(VkDescriptorSet set)

--- a/app/src/main/cpp/rpcs3/rpcs3/Emu/RSX/VK/vkutils/descriptors.h
+++ b/app/src/main/cpp/rpcs3/rpcs3/Emu/RSX/VK/vkutils/descriptors.h
@@ -39,28 +39,45 @@ namespace vk
 		descriptor_pool() = default;
 		~descriptor_pool() = default;
 
-		void create(const vk::render_device& dev, const rsx::simple_array<VkDescriptorPoolSize>& pool_sizes, u32 max_sets = 1024);
+		void create(const vk::render_device& dev, const rsx::simple_array<VkDescriptorPoolSize>& pool_sizes, u32 min_sets = 1024, u32 max_sets = 1024);
 		void destroy();
 
 		VkDescriptorSet allocate(VkDescriptorSetLayout layout, VkBool32 use_cache = VK_TRUE);
 
 		operator VkDescriptorPool() { return m_current_pool_handle; }
 		FORCE_INLINE bool valid() const { return !m_device_subpools.empty(); }
-		FORCE_INLINE u32 max_sets() const { return m_create_info.maxSets; }
+		FORCE_INLINE u32 max_sets() const { return m_current_subpool_index >= m_device_subpools.size() ? 0u : m_device_subpools[m_current_subpool_index].size; }
 
 	private:
-		FORCE_INLINE bool can_allocate(u32 required_count, u32 already_used_count = 0) const { return (required_count + already_used_count) <= m_create_info.maxSets; };
+		FORCE_INLINE bool can_allocate(u32 required_count, u32 already_used_count = 0) const { return (required_count + already_used_count) <= max_sets(); };
 		void reset(u32 subpool_id, VkDescriptorPoolResetFlags flags);
 		void next_subpool();
 
+		std::pair<VkResult, VkDescriptorPool> new_subpool();
+
 		struct logical_subpool_t
 		{
-			VkDescriptorPool handle;
-			VkBool32 busy;
+			VkDescriptorPool handle = VK_NULL_HANDLE;
+			u32 size = 0;
+			VkBool32 busy = VK_FALSE;
+		};
+
+		struct autoscaling_config_t
+		{
+			u32 min_pool_size = 0;
+			u32 max_pool_size = 0;
+			u32 current_size = 0;
+
+			// Debounce setup.
+			static constexpr u32 increment_min_steps = 2u;
+			u32 increment_steps = 0;
+
+			u32 get_pool_size();
 		};
 
 		const vk::render_device* m_owner = nullptr;
 		VkDescriptorPoolCreateInfo m_create_info = {};
+		autoscaling_config_t m_autoscaling_config = {};
 		rsx::simple_array<VkDescriptorPoolSize> m_create_info_pool_sizes;
 
 		rsx::simple_array<logical_subpool_t> m_device_subpools;


### PR DESCRIPTION

## Summary

Backports the **already-merged** upstream RPCS3 fix [**#18844 — "vk: Autogrow descriptor pools based on demand"**](https://github.com/RPCS3/rpcs3/pull/18844) onto the fork's current 0.0.40 base, adapted to the Android Vulkan PFN table. It fixes the Gran Turismo 5 high-memory-usage crash ([upstream issue #18819](https://github.com/RPCS3/rpcs3/issues/18819)) that the 0.0.40 base inherits.

This is a **focused single-fix backport, not a full RPCS3 version bump** — see "Scope" below.

**Testable build:** an unofficial APK carrying this fix (alongside the persistent-pipeline-cache fix from #122) is published as [`shader-patch-2`](https://github.com/mercurious/aps3e/releases/tag/shader-patch-2) for anyone who wants to reproduce the result below.

## The bug

Upstream [#18819](https://github.com/RPCS3/rpcs3/issues/18819) — *[BCES/BCUS] Gran Turismo 5: High memory usage after Vulkan binding-model rewrites*: the descriptor pool over-allocates fixed-size pools, growing ~300 MB **per car viewed** in the dealership/garage until the title silently closes for lack of RAM. The fork's 0.0.40 base predates the fix, so it carries the regression.

## The fix

Upstream PR #18844 (merged 2026-06-05, ships in 0.0.41) makes `descriptor_pool` **scale subpool size on demand** between a `min`/`max` bound with a 2-step debounce, instead of allocating fixed maximally-sized pools up front.

## What this PR changes

3 files, **+89 / −15** — byte-for-byte the upstream diff, with one Android adaptation:

| File | Change |
|---|---|
| `vkutils/descriptors.h` | `create()` gains `min_sets`; new `new_subpool()`, `autoscaling_config_t`, `get_pool_size()`; `logical_subpool_t` gains `size` |
| `vkutils/descriptors.cpp` | autoscaling pool sizing; `next_subpool()` now routes through `new_subpool()` |
| `VKProgramPipeline.cpp` | pool created with `(16u, 4096u)` min/max |

**Only adaptation vs upstream:** the new pool-creation call goes through the fork's manual PFN table (`_vkCreateDescriptorPool`) instead of the direct symbol — `vkCreateDescriptorPool` is already exported in `VKPFNTable.h`, so no table change was needed.

## Scope (what this is and isn't)

- ✅ Fixes **the GT5 descriptor-pool memory leak** specifically.
- ❌ Not a 0.0.41 vendor bump. The fork's VK backend diverges from upstream (manual PFN table), so a full bump is a separate, larger effort; this is the one accepted upstream fix that resolves the GT5 crash, in isolation.
- ❌ Does **not** address an unrelated silent native crash (`libe.so` SIGABRT under heavy on-the-fly shader compilation) that still exists — out of scope here.

## Validation / evidence

On-device: **Retroid Pocket Flip 2 (SM8250) / Adreno 650 / Turnip Mesa 26.1.2 / 7.7 GB RAM**, GT5P Spec III (`NPEA00050`). One **30-minute** continuous session deliberately stressing the leak path — 5 laps at Eiger Nordwand, then a **full dealership car-by-car shader harvest** (the exact path that ballooned pre-fix), then a Daytona multi-car race. `aenu.aps3e:emu` PSS sampled every 6 s:

| Phase | PSS | Free RAM | Read |
|---|---|---|---|
| Racing (5 laps) | flat **~3.0–3.3 GB** | ~2.1 GB | steady-state stable |
| Full dealership harvest | 3.3 → **4.3 GB** (graphics-led: 0.76 → 1.9 GB) | 2.1 → ~1.0 GB | growth tracks **real new shaders**, not descriptor bloat |
| Daytona multi-car | **plateau 4.34 GB** | floor **934 MB** | held, never exhausted |

Pre-fix this leaked ~300 MB **per car**; here the entire dealership pass cost a few tens of MB/car dominated by genuinely-new harvested pipelines, and **free RAM never dropped below 934 MB with no OOM/LMK kill** across 30 min.

![GT5P Spec III 30-min memory trace](https://github.com/mercurious/aps3e/releases/download/shader-patch-2/gt5p_memory_trace.png)

*Honest caveat: single extended session, n=1 device. Strong signal, not a statistical claim.*

## Credits

Backport + on-device validation by **mercurious** (with **Claude Opus 4.8**).
Original fix: upstream RPCS3 [#18844](https://github.com/RPCS3/rpcs3/pull/18844) (elad335 et al.).
