### PR TITLE
Shader Cache Manager — export/import a game's portable shader cache

### DIFF
--- a/app/src/main/java/aenu/aps3e/UserDataActivity.java
+++ b/app/src/main/java/aenu/aps3e/UserDataActivity.java
@@ -572,6 +572,10 @@ public class UserDataActivity extends AppCompatActivity {
             public void run(ProgressTask task) {
                 try {
                     zip_shader_cache(dir, save_to_file);
+                    // Register with MediaStore so the export shows up in the Files app / system
+                    // share picker (files written via the File API aren't indexed automatically).
+                    android.media.MediaScannerConnection.scanFile(getApplicationContext(),
+                            new String[]{save_to_file.getAbsolutePath()}, new String[]{"application/zip"}, null);
                     task.task_handler.sendEmptyMessage(ProgressTask.TASK_DONE);
                 } catch (Exception e) {
                     task.task_handler.sendEmptyMessage(ProgressTask.TASK_FAILED);

--- a/app/src/main/java/aenu/aps3e/UserDataActivity.java
+++ b/app/src/main/java/aenu/aps3e/UserDataActivity.java
@@ -72,11 +72,13 @@ public class UserDataActivity extends AppCompatActivity {
     public static final int PAGE_TYPE_COMPATIBILITY_TABLE = 3;
     public static final int PAGE_TYPE_DRIVER_MANAGER = 4;
     public static final int PAGE_TYPE_GAME_DATA_MANAGER = 5;
+    public static final int PAGE_TYPE_SHADER_CACHE_MANAGER = 6;
 
     private static final int REQUEST_EXPORT_PPU_CACHE = 6201;
     private static final int REQUEST_IMPORT_PPU_CACHE = 6202;
     private static final int REQUEST_SELECT_ISO_DIR = 6203;
     private static final int REQUEST_IMPORT_GAME_DATA = 6204;
+    private static final int REQUEST_IMPORT_SHADER_CACHE = 6205;
 
     private int current_page_type = PAGE_TYPE_MAIN;
 
@@ -127,6 +129,7 @@ public class UserDataActivity extends AppCompatActivity {
         layout_list.put(PAGE_TYPE_COMPATIBILITY_TABLE, findViewById(R.id.compatibility_table_view));
         layout_list.put(PAGE_TYPE_DRIVER_MANAGER, findViewById(R.id.list_driver));
         layout_list.put(PAGE_TYPE_GAME_DATA_MANAGER, findViewById(R.id.game_data_view));
+        layout_list.put(PAGE_TYPE_SHADER_CACHE_MANAGER, findViewById(R.id.shader_cache_view));
     }
 
     private void handle_back_pressed() {
@@ -144,6 +147,9 @@ public class UserDataActivity extends AppCompatActivity {
                 case PAGE_TYPE_PPU_CACHE_MANAGER:
                     show_ppu_cache_page();
                     break;
+                case PAGE_TYPE_SHADER_CACHE_MANAGER:
+                    show_shader_cache_page();
+                    break;
                 case PAGE_TYPE_ISO_DIR_MANAGER:
                     show_iso_dir_page();
                     break;
@@ -159,6 +165,8 @@ public class UserDataActivity extends AppCompatActivity {
             }
         } else if (current_page_type == PAGE_TYPE_PPU_CACHE_MANAGER) {
             handle_ppu_cache_item_click(adapter, position);
+        } else if (current_page_type == PAGE_TYPE_SHADER_CACHE_MANAGER) {
+            handle_shader_cache_item_click(adapter, position);
         } else if (current_page_type == PAGE_TYPE_ISO_DIR_MANAGER) {
             handle_iso_dir_item_click(adapter, position);
         } else if (current_page_type == PAGE_TYPE_COMPATIBILITY_TABLE) {
@@ -178,6 +186,7 @@ public class UserDataActivity extends AppCompatActivity {
 
         ArrayList<PageInfo> titles = new ArrayList<>();
         titles.add(new PageInfo(R.string.ppu_cache_manager, PAGE_TYPE_PPU_CACHE_MANAGER));
+        titles.add(new PageInfo(R.string.shader_cache_manager, PAGE_TYPE_SHADER_CACHE_MANAGER));
         titles.add(new PageInfo(R.string.iso_dir_manager, PAGE_TYPE_ISO_DIR_MANAGER));
         titles.add(new PageInfo(R.string.compatibility_table, PAGE_TYPE_COMPATIBILITY_TABLE));
         titles.add(new PageInfo(R.string.game_data_manager, PAGE_TYPE_GAME_DATA_MANAGER));
@@ -477,6 +486,209 @@ public class UserDataActivity extends AppCompatActivity {
         }
     }
 
+    // ---- Shader Cache Manager (mirrors PPU Cache Manager, scoped to shaders_cache/ = the GPU-portable layer) ----
+
+    private void show_shader_cache_page() {
+        View layout=select_layout(PAGE_TYPE_SHADER_CACHE_MANAGER);
+        ListView listShaderCache = (ListView) layout.findViewById(R.id.list_shader_cache);
+
+        final int titleResId = R.string.shader_cache_manager;
+        if(getSupportActionBar()!=null) {
+            getSupportActionBar().setTitle(getString(titleResId));
+        }
+
+        Button btn_import = (Button) layout.findViewById(R.id.btn_shader_import);
+        btn_import.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                MainActivity.request_file_select(UserDataActivity.this, REQUEST_IMPORT_SHADER_CACHE);
+            }
+        });
+
+        final File[] _all_ppu_cache_dirs = MainActivity.get_all_ppu_cache_dirs();
+        final ArrayList<File> list = new ArrayList<>();
+        if(_all_ppu_cache_dirs!=null) for(File dir:_all_ppu_cache_dirs) {
+            if(dir.getName().length()==9)
+                list.add(dir);
+        }
+
+        listShaderCache.setAdapter(new ArrayAdapter<File>(this, android.R.layout.simple_list_item_2, list){
+            @Override
+            public View getView(int position, View convertView, ViewGroup parent) {
+                if(convertView==null)
+                    convertView = getLayoutInflater().inflate(android.R.layout.simple_list_item_2, parent, false);
+                TextView text1 = convertView.findViewById(android.R.id.text1);
+                TextView text2 = convertView.findViewById(android.R.id.text2);
+                String serial = getItem(position).getName();
+                text1.setText(getGameName(serial));
+                text2.setText(serial);
+                return convertView;
+            }
+        });
+        listShaderCache.setOnItemClickListener(new AdapterView.OnItemClickListener() {
+            @Override
+            public void onItemClick(AdapterView<?> parent, View view, int position, long id) {
+                handle_item_click((ListAdapter) parent.getAdapter(), position);
+            }
+        });
+
+        current_page_type = PAGE_TYPE_SHADER_CACHE_MANAGER;
+    }
+
+    private void handle_shader_cache_item_click(ListAdapter adapter, int position) {
+        File item = (File) adapter.getItem(position);
+        String[] options = {getString(R.string.export_shader_cache)};
+        new AlertDialog.Builder(this)
+                .setTitle(getGameName(item.getName()))
+                .setItems(options, new DialogInterface.OnClickListener() {
+                    @Override
+                    public void onClick(DialogInterface dialog, int which) {
+                        switch (which) {
+                            case 0:
+                                export_shader_cache(item);
+                                break;
+                        }
+                    }
+                })
+                .show();
+    }
+
+    void export_shader_cache(File dir){
+        File save_to_dir = new File(Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS), "aps3e");
+        if (!save_to_dir.exists()) {
+            save_to_dir.mkdirs();
+        }
+        final String save_name = dir.getName() + "-shaders.zip";
+        final File save_to_file = new File(save_to_dir, save_name);
+
+        ProgressTask pt=new ProgressTask(this);
+        pt.set_done_task(new ProgressTask.UI_Task(){
+            @Override
+            public void run() {
+                Toast.makeText(UserDataActivity.this,String.format(getString(R.string.save_to),save_to_file.getAbsolutePath()),Toast.LENGTH_LONG).show();
+            }
+        }).call(new ProgressTask.Task(){
+            @Override
+            public void run(ProgressTask task) {
+                try {
+                    zip_shader_cache(dir, save_to_file);
+                    task.task_handler.sendEmptyMessage(ProgressTask.TASK_DONE);
+                } catch (Exception e) {
+                    task.task_handler.sendEmptyMessage(ProgressTask.TASK_FAILED);
+                }
+            }
+        });
+    }
+
+    private static boolean zip_shader_cache(File dir, File out_f) throws Exception {
+        FileOutputStream fos=null;
+        ZipOutputStream zos=null;
+        try{
+            fos=new FileOutputStream(out_f);
+            zos=new java.util.zip.ZipOutputStream(fos);
+            zip_shader_cache_file(dir, zos, "");
+        } finally {
+            if(zos!=null) zos.close();
+            if(fos!=null) fos.close();
+        }
+        return true;
+    }
+
+    private static void zip_shader_cache_file(File file, ZipOutputStream zos, String path) throws Exception {
+        String entryName = path + file.getName();
+        if (file.isDirectory()) {
+            File[] files = file.listFiles();
+            if (files != null) {
+                for (File f : files) {
+                    zip_shader_cache_file(f, zos, entryName + "/");
+                }
+            }
+        } else if(("/"+entryName).contains("/shaders_cache/")){
+            ZipEntry zip_entry = new ZipEntry(entryName);
+            zos.putNextEntry(zip_entry);
+            try (FileInputStream fis = new FileInputStream(file)) {
+                byte[] buffer = new byte[16384];
+                int len;
+                while ((len = fis.read(buffer)) > 0) {
+                    zos.write(buffer, 0, len);
+                }
+            }
+            zos.closeEntry();
+        }
+    }
+
+    void handle_import_shader_cache(Uri uri) {
+        ProgressTask pt = new ProgressTask(this);
+        pt.set_done_task(new ProgressTask.UI_Task() {
+            @Override
+            public void run() {
+                Toast.makeText(UserDataActivity.this, R.string.import_shader_cache_done, Toast.LENGTH_SHORT).show();
+                show_shader_cache_page();
+            }
+        }).set_failed_task(new ProgressTask.UI_Task() {
+            @Override
+            public void run() {
+                Toast.makeText(UserDataActivity.this, R.string.import_shader_cache_failed, Toast.LENGTH_SHORT).show();
+            }
+        }).call(new ProgressTask.Task() {
+            @Override
+            public void run(ProgressTask task) {
+                try {
+                    import_shader_cache_from_uri(uri);
+                    task.task_handler.sendEmptyMessage(ProgressTask.TASK_DONE);
+                } catch (Exception e) {
+                    Log.e("APS3E", String.valueOf(e.getMessage()));
+                    e.printStackTrace();
+                    task.task_handler.sendEmptyMessage(ProgressTask.TASK_FAILED);
+                }
+            }
+        });
+    }
+
+    private void import_shader_cache_from_uri(Uri uri) throws Exception {
+        ParcelFileDescriptor pfd = getContentResolver().openFileDescriptor(uri, "r");
+        if (pfd == null) {
+            throw new RuntimeException("xx");
+        }
+        FileInputStream fis = new FileInputStream(pfd.getFileDescriptor());
+        ZipInputStream zis = new ZipInputStream(fis);
+
+        File cache_base_dir = get_ppu_cache_base_dir();
+        if (!cache_base_dir.exists()) {
+            cache_base_dir.mkdirs();
+        }
+
+        ZipEntry entry;
+        int extracted_count = 0;
+        while ((entry = zis.getNextEntry()) != null) {
+            if (entry.isDirectory()) { continue; }
+            String entry_name = entry.getName();
+            if (!("/"+entry_name).contains("/shaders_cache/")) {
+                zis.closeEntry();
+                continue;
+            }
+            String sub_path=entry_name.substring(0, entry_name.lastIndexOf("/"));
+            File targetDir = new File(cache_base_dir, sub_path);
+            if (!targetDir.exists()) { targetDir.mkdirs(); }
+            File out_f = new File(targetDir, entry_name.substring(entry_name.lastIndexOf("/") + 1));
+            FileOutputStream fos = new FileOutputStream(out_f);
+            byte[] buffer = new byte[16384];
+            int len;
+            while ((len = zis.read(buffer)) > 0) {
+                fos.write(buffer, 0, len);
+            }
+            fos.close();
+            extracted_count++;
+            zis.closeEntry();
+        }
+        zis.close();
+        fis.close();
+        pfd.close();
+        if (extracted_count == 0) {
+            throw new Exception("no shader cache files found");
+        }
+    }
+
     @Override
     protected void onActivityResult(int requestCode, int resultCode, Intent data) {
         super.onActivityResult(requestCode, resultCode, data);
@@ -495,6 +707,9 @@ public class UserDataActivity extends AppCompatActivity {
                 break;
             case REQUEST_IMPORT_PPU_CACHE:
                 handle_import_ppu_cache(uri);
+                break;
+            case REQUEST_IMPORT_SHADER_CACHE:
+                handle_import_shader_cache(uri);
                 break;
             case REQUEST_SELECT_ISO_DIR:
                 handle_add_iso_dir(uri);

--- a/app/src/main/res/layout/activity_user_data.xml
+++ b/app/src/main/res/layout/activity_user_data.xml
@@ -49,6 +49,28 @@
 				android:scrollbars="vertical" />
 		</LinearLayout>
 		
+		<!-- Shader Cache Manager -->
+		<LinearLayout
+			android:id="@+id/shader_cache_view"
+			android:layout_width="match_parent"
+			android:layout_height="match_parent"
+			android:orientation="vertical"
+			android:visibility="gone">
+
+			<Button
+				android:id="@+id/btn_shader_import"
+				android:layout_width="match_parent"
+				android:layout_height="wrap_content"
+				android:text="@string/import_shader_cache"
+				android:layout_margin="8dp" />
+
+			<ListView
+				android:id="@+id/list_shader_cache"
+				android:layout_width="match_parent"
+				android:layout_height="match_parent"
+				android:scrollbars="vertical" />
+		</LinearLayout>
+
 		<!-- ISO 目录管理 -->
 		<LinearLayout
 			android:id="@+id/iso_dir_view"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -18,6 +18,11 @@
 	<string name="export_ppu_cache">Export PPU Cache</string>
 	<string name="import_ppu_cache_done">PPU cache import completed</string>
 	<string name="import_ppu_cache_failed">PPU cache import failed</string>
+	<string name="shader_cache_manager">Shader Cache Manager</string>
+	<string name="import_shader_cache">Import Shader Cache</string>
+	<string name="export_shader_cache">Export Shader Cache</string>
+	<string name="import_shader_cache_done">Shader cache import completed</string>
+	<string name="import_shader_cache_failed">Shader cache import failed</string>
 	<string name="iso_dir_manager">ISO Directory Manager</string>
 	<string name="compatibility_table">Game Compatibility Table</string>
 	<string name="driver_manager">Driver Manager</string>


### PR DESCRIPTION
## Summary

Adds a **Shader Cache Manager** under *User Data Manager*, mirroring the existing **PPU Cache Manager** but scoped to the RPCS3 `shaders_cache/` subtree — letting a player export a game's shader cache to a zip and import one back.

## Why scope it to `shaders_cache/`

That subtree is the **GPU/driver-agnostic, RPCS3-version-locked** layer (decompiled shader + pipeline state — no native ISA). It ports across devices, GPUs, and platforms at the same RPCS3 version, so a Snapdragon/Turnip player's pack is usable by a Mali player and vice-versa. Crucially, the driver pipeline cache (`vk_pipeline_cache.bin`) lives in the *parent* per-title dir, **outside** `shaders_cache/` — so scoping the zip to `shaders_cache/` automatically excludes the non-portable, device-locked blob. Players skip the cold per-pipeline rediscovery on first launch and just compile the complete set once.

## What it adds

- A new *User Data Manager* page listing per-game caches (reuses `get_all_ppu_cache_dirs()` + `getGameName()`).
- Per-game **Export Shader Cache** → `Downloads/aps3e/<serial>-shaders.zip`.
- An **Import Shader Cache** button (file picker) → extracts into `cache/cache/`, reconstructing the per-title path (the dir hash is derived from the game executable, so it matches across devices).
- Wires into the existing `onActivityResult` flow and reuses the `ProgressTask` + zip/unzip helpers.

## Files

3 files, +242: `UserDataActivity.java` (page + export/import), `res/layout/activity_user_data.xml` (`shader_cache_view`), `res/values/strings.xml`.

## Notes

Import is user-picks-a-file — the same posture as the **Import PPU Cache** that already ships. Memory-safe and read-mostly (export never mutates device state). Validated on-device (Retroid Pocket Flip 2).

Authored by **mercurious** (with **Claude Opus 4.8**).
